### PR TITLE
fix: enable some disabled compiler warnings

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -55,8 +55,10 @@
                                 '/W3',
                                 '/Qspectre',
                                 '/guard:cf',
-                                '-std:c++17'
-                            ]
+                                '-std:c++17',
+                                '/w34244',
+                                '/w34267'
+                            ],
                         },
                         'VCLinkerTool': {
                             'AdditionalOptions': [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-policy-watcher",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/windows/NumberPolicy.cc
+++ b/src/windows/NumberPolicy.cc
@@ -17,5 +17,5 @@ long long NumberPolicy::parseRegistryValue(LPBYTE buffer, DWORD bufferSize) cons
 
 Value NumberPolicy::getJSValue(Env env, long long value) const
 {
-  return Number::New(env, (double)value);
+  return Number::New(env, static_cast<double>(value));
 }

--- a/src/windows/NumberPolicy.cc
+++ b/src/windows/NumberPolicy.cc
@@ -17,5 +17,5 @@ long long NumberPolicy::parseRegistryValue(LPBYTE buffer, DWORD bufferSize) cons
 
 Value NumberPolicy::getJSValue(Env env, long long value) const
 {
-  return Number::New(env, value);
+  return Number::New(env, (double)value);
 }


### PR DESCRIPTION
Fixes an S360 item that was complaining about warnings 4244 and 4267 being disabled, by setting those warnings as level 3 warnings, which works because we also pass in the /W3 flag to show those warnings.