### PR TITLE
fix: Woverloaded-virtual and Wdelete-abstract-non-virtual-dtor warnings

### DIFF
--- a/src/Policy.hh
+++ b/src/Policy.hh
@@ -13,6 +13,7 @@ using namespace Napi;
 class Policy
 {
 public:
+  virtual ~Policy() {}
   virtual bool refresh() = 0;
   virtual Value getValue(Env env) const = 0;
   const std::string name;

--- a/src/PolicyWatcher.hh
+++ b/src/PolicyWatcher.hh
@@ -27,8 +27,6 @@ public:
 
   void OnExecute(Napi::Env env);
   void Execute(const ExecutionProgress &progress);
-  void OnOK();
-  void OnError();
   void OnProgress(const Policy *const *policies, size_t count);
   void Dispose();
 

--- a/src/linux/PolicyWatcher.cc
+++ b/src/linux/PolicyWatcher.cc
@@ -21,7 +21,5 @@ void PolicyWatcher::AddStringPolicy(const std::string name) {}
 void PolicyWatcher::AddNumberPolicy(const std::string name) {}
 void PolicyWatcher::OnExecute(Napi::Env env) {}
 void PolicyWatcher::Execute(const ExecutionProgress &progress) {}
-void PolicyWatcher::OnOK() {}
-void PolicyWatcher::OnError() {}
 void PolicyWatcher::OnProgress(const Policy *const *policies, size_t count) {}
 void PolicyWatcher::Dispose() {}

--- a/src/macos/PolicyWatcher.cc
+++ b/src/macos/PolicyWatcher.cc
@@ -21,7 +21,5 @@ void PolicyWatcher::AddStringPolicy(const std::string name) {}
 void PolicyWatcher::AddNumberPolicy(const std::string name) {}
 void PolicyWatcher::OnExecute(Napi::Env env) {}
 void PolicyWatcher::Execute(const ExecutionProgress &progress) {}
-void PolicyWatcher::OnOK() {}
-void PolicyWatcher::OnError() {}
 void PolicyWatcher::OnProgress(const Policy *const *policies, size_t count) {}
 void PolicyWatcher::Dispose() {}

--- a/src/windows/PolicyWatcher.cc
+++ b/src/windows/PolicyWatcher.cc
@@ -83,9 +83,6 @@ void PolicyWatcher::Execute(const ExecutionProgress &progress)
   }
 }
 
-void PolicyWatcher::OnOK() {}
-void PolicyWatcher::OnError() {}
-
 void PolicyWatcher::OnProgress(const Policy *const *policies, size_t count)
 {
   HandleScope scope(Env());


### PR DESCRIPTION
Identified when working on https://github.com/microsoft/vscode/pull/180466

```
In file included from ../src/main.cc:10:
../src/PolicyWatcher.hh:31:8: warning: 'PolicyWatcher::OnError' hides overloaded virtual function [-Woverloaded-virtual]
  void OnError();
       ^
../node_modules/node-addon-api/napi.h:2481:16: note: hidden overloaded virtual function 'Napi::AsyncWorker::OnError' declared here: different number of parameters (1 vs 0)
  virtual void OnError(const Error& e);



              ^
/mnt/vss/_work/1/s/.build/libcxx_headers/include/__memory/allocator_traits.h:315:13: note: in instantiation of member function 'std::allocator<std::unique_ptr<Policy>>::destroy' requested here
        __a.destroy(__p);
            ^
/mnt/vss/_work/1/s/.build/libcxx_headers/include/vector:836:25: note: in instantiation of function template specialization 'std::allocator_traits<std::allocator<std::unique_ptr<Policy>>>::destroy<std::unique_ptr<Policy>, void>' requested here
        __alloc_traits::destroy(__alloc(), std::__to_address(--__soon_to_be_end));
                        ^
/mnt/vss/_work/1/s/.build/libcxx_headers/include/vector:830:29: note: in instantiation of member function 'std::vector<std::unique_ptr<Policy>>::__base_destruct_at_end' requested here
  void __clear() _NOEXCEPT {__base_destruct_at_end(this->__begin_);}
                            ^
/mnt/vss/_work/1/s/.build/libcxx_headers/include/vector:446:20: note: in instantiation of member function 'std::vector<std::unique_ptr<Policy>>::__clear' requested here
            __vec_.__clear();
                   ^
/mnt/vss/_work/1/s/.build/libcxx_headers/include/vector:456:67: note: in instantiation of member function 'std::vector<std::unique_ptr<Policy>>::__destroy_vector::operator()' requested here
  _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI ~vector() { __destroy_vector(*this)(); }
                                                                  ^
../src/main.cc:39:19: note: in instantiation of member function 'std::vector<std::unique_ptr<Policy>>::~vector' requested here
  auto policies = std::vector<std::unique_ptr<Policy>>();
```