### PR TITLE
chore: bump Node versions and remove Windows32

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,14 +28,11 @@ extends:
           - script: npm ci
         testPlatforms:
           - name: Linux
-            nodeVersions: [16.x]
+            nodeVersions: [18.17.x]
           - name: MacOS
-            nodeVersions: [16.x]
+            nodeVersions: [18.17.x]
           - name: Windows
-            nodeVersions: [16.x]
-          - name: Windows32
-            nodeVersions: [16.x]
-            force32bitNode: true
+            nodeVersions: [18.17.x]
         testSteps:
           - script: npm ci
             env:


### PR DESCRIPTION
We ended Windows 32-bit support for VS Code, and Node 16 reached EOL, so this PR removes Windows 32-bit support and updates the Node version used in the pipeline.