### PR TITLE
fix: swallow unhandled exceptions on shutdown

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -5,11 +5,13 @@
             "sources": [
                 "src/main.cc"
             ],
+            "dependencies": [
+                "<!(node -p \"require('node-addon-api').targets\"):node_addon_api_except"
+            ],
             "include_dirs": [
                 "<!(node -p \"require('node-addon-api').include_dir\")"
             ],
-            'cflags!': ['-fno-exceptions'],
-            'cflags_cc!': ['-fno-exceptions'],
+            "defines": [ "NODE_API_SWALLOW_UNTHROWABLE_EXCEPTIONS" ],
             'conditions': [
                 ['OS=="mac"', {
                     "sources": [
@@ -17,10 +19,7 @@
                     ],
                     "defines": [
                         "MACOS",
-                    ],
-                    "xcode_settings": {
-                        "GCC_ENABLE_CPP_EXCEPTIONS": "YES"
-                    }
+                    ]
                 }],
                 ['OS=="mac" and target_arch=="arm64"', {
                     "xcode_settings": {
@@ -42,8 +41,7 @@
                         "src/windows/NumberPolicy.cc"
                     ],
                     "defines": [
-                        "WINDOWS",
-                        "_HAS_EXCEPTIONS=1"
+                        "WINDOWS"
                     ],
                     "libraries": [
                         "userenv.lib"
@@ -53,10 +51,8 @@
                     },
                     "msvs_settings": {
                         "VCCLCompilerTool": {
-                            "ExceptionHandling": 1,
                             'AdditionalOptions': [
                                 '/guard:cf',
-                                '-std:c++17',
                                 '/we4244',
                                 '/we4267',
                                 '/ZH:SHA_256'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vscode/policy-watcher",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vscode/policy-watcher",
-      "version": "1.1.7",
+      "version": "1.1.8",
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vscode/policy-watcher",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Addresses failure https://dev.azure.com/vscode/VSCode/_build/results?buildId=133283&view=logs&j=087ff425-4815-510c-015a-6444fffaa352&t=5547c453-0547-5e1f-22ff-38d98b3b288a

Exceptions thrown after Node.js environment shutdown cannot be handled, the flag allows to simply ignore them in the binding layer.