### PR TITLE
Implement MacOS 

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -13,7 +13,21 @@
       "cStandard": "c17",
       "cppStandard": "c++17",
       "intelliSenseMode": "windows-msvc-x64"
+    },
+    {
+      "name": "Mac",
+      "includePath": [
+        "${workspaceFolder}/**",
+        "${workspaceFolder}/node_modules/node-addon-api",
+        "${default}"
+      ],
+      "defines": ["_DEBUG", "MACOS"],
+      "compilerPath": "/usr/bin/clang++",
+      "cStandard": "c17",
+      "cppStandard": "c++17",
+      "intelliSenseMode": "macos-clang-x64"
     }
   ],
   "version": 4
 }
+  

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+    
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Program",
+            "program": "${workspaceFolder}/index.js"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -67,7 +67,19 @@
     "xstring": "cpp",
     "xtr1common": "cpp",
     "xtree": "cpp",
-    "xutility": "cpp"
+    "xutility": "cpp",
+    "__bit_reference": "cpp",
+    "__locale": "cpp",
+    "__split_buffer": "cpp",
+    "__threading_support": "cpp",
+    "__verbose_abort": "cpp",
+    "cstdarg": "cpp",
+    "cwctype": "cpp",
+    "execution": "cpp",
+    "string_view": "cpp",
+    "variant": "cpp",
+    "bitset": "cpp",
+    "print": "cpp"
   },
   "git.branchProtection": ["main"],
   "git.branchProtectionPrompt": "alwaysCommitToNewBranch"

--- a/binding.gyp
+++ b/binding.gyp
@@ -16,6 +16,8 @@
                 ['OS=="mac"', {
                     "sources": [
                         "src/macos/PolicyWatcher.cc",
+                        "src/macos/StringPolicy.cc",
+                        "src/macos/NumberPolicy.cc"
                     ],
                     "defines": [
                         "MACOS",

--- a/index.js
+++ b/index.js
@@ -6,8 +6,11 @@
 exports.createWatcher = require('bindings')('vscode-policy-watcher');
 
 if (require.main === module) {
+  const platform = process.platform;
   exports.createWatcher(
-    'CodeOSS',
+    platform === 'darwin'
+      ? 'com.visualstudio.code.oss'  // MacOS
+      : 'CodeOSS',                   // Windows
     {
       UpdateMode: { type: 'string' },
       SCMInputFontSize: { type: 'number' },

--- a/src/PolicyWatcher.hh
+++ b/src/PolicyWatcher.hh
@@ -14,6 +14,11 @@
 #include <windows.h>
 #endif
 
+#ifdef MACOS
+#define Boolean CFBoolean
+#include <CoreServices/CoreServices.h>
+#endif
+
 using namespace Napi;
 
 class PolicyWatcher : public AsyncProgressQueueWorker<const Policy *>
@@ -37,6 +42,13 @@ protected:
 #ifdef WINDOWS
   HANDLE handles[4];
 #endif
+
+#ifdef MACOS
+  FSEventStreamRef stream;
+  dispatch_semaphore_t sem;
+  bool disposed;
+#endif
+
 };
 
 #endif

--- a/src/macos/NumberPolicy.cc
+++ b/src/macos/NumberPolicy.cc
@@ -1,0 +1,42 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+#include "NumberPolicy.hh"
+
+using namespace Napi;
+
+NumberPolicy::NumberPolicy(const std::string name, const std::string &productName)
+    : PreferencesPolicy(name, productName)
+{
+}
+
+Value NumberPolicy::getJSValue(Env env, long long value) const
+{
+  return Number::New(env, static_cast<double>(value));
+}
+
+std::optional<long long> NumberPolicy::read() const
+{
+  auto pref = CFPreferencesCopyAppValue(key, appID);
+
+  if (pref == NULL)
+    return std::nullopt;
+
+  if (CFGetTypeID(pref) != CFNumberGetTypeID())
+  {
+    CFRelease(pref);
+    return std::nullopt;
+  }
+
+  long long value;
+  if (CFNumberGetValue((CFNumberRef)pref, kCFNumberLongLongType, &value))
+  {
+    CFRelease(pref);
+    return value;
+  }
+
+  CFRelease(pref);
+  return std::nullopt;
+}

--- a/src/macos/NumberPolicy.hh
+++ b/src/macos/NumberPolicy.hh
@@ -1,0 +1,24 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+#ifndef MAC_NUMBER_POLICY_H
+#define MAC_NUMBER_POLICY_H
+
+#include <napi.h>
+#include "PreferencesPolicy.hh"
+
+using namespace Napi;
+
+class NumberPolicy : public PreferencesPolicy<long long>
+{
+public:
+  NumberPolicy(const std::string name, const std::string &productName);
+  std::optional<long long> read() const override;
+
+protected:
+  Value getJSValue(Env env, long long value) const override;
+};
+
+#endif

--- a/src/macos/PolicyWatcher.cc
+++ b/src/macos/PolicyWatcher.cc
@@ -4,22 +4,113 @@
  *--------------------------------------------------------------------------------------------*/
 
 #include "../PolicyWatcher.hh"
+#include "StringPolicy.hh"
+#include "NumberPolicy.hh"
+#include <thread>
 
 using namespace Napi;
 
+static void fsevents_callback(ConstFSEventStreamRef streamRef,
+                            void *clientCallBackInfo,
+                            size_t numEvents,
+                            void *eventPaths,
+                            const FSEventStreamEventFlags eventFlags[],
+                            const FSEventStreamEventId eventIds[])
+{
+    dispatch_semaphore_t *sem = (dispatch_semaphore_t *)clientCallBackInfo;
+    dispatch_semaphore_signal(*sem);
+}
+
 PolicyWatcher::PolicyWatcher(std::string productName, const Function &okCallback)
     : AsyncProgressQueueWorker(okCallback),
-      productName(productName)
+      productName(productName),
+      stream(nullptr),
+      sem(nullptr),
+      disposed(false)
 {
 }
 
 PolicyWatcher::~PolicyWatcher()
 {
+    if (stream) {
+        FSEventStreamStop(stream);
+        FSEventStreamInvalidate(stream);
+        FSEventStreamRelease(stream);
+    }
+    if (sem) {
+        dispatch_release(sem);
+    }
 }
 
-void PolicyWatcher::AddStringPolicy(const std::string name) {}
-void PolicyWatcher::AddNumberPolicy(const std::string name) {}
-void PolicyWatcher::OnExecute(Napi::Env env) {}
-void PolicyWatcher::Execute(const ExecutionProgress &progress) {}
-void PolicyWatcher::OnProgress(const Policy *const *policies, size_t count) {}
-void PolicyWatcher::Dispose() {}
+void PolicyWatcher::AddStringPolicy(const std::string name)
+{
+  policies.push_back(std::make_unique<StringPolicy>(name, productName));
+}
+void PolicyWatcher::AddNumberPolicy(const std::string name)
+{
+    policies.push_back(std::make_unique<NumberPolicy>(name, productName));
+}
+
+void PolicyWatcher::OnExecute(Napi::Env env)
+{
+  AsyncProgressQueueWorker::OnExecute(env);
+}
+
+void PolicyWatcher::Execute(const ExecutionProgress &progress)
+{
+    std::vector<const Policy *> updatedPolicies;
+    bool first = true;
+
+    // Watch for changes
+    CFStringRef path = CFSTR("/Library/Managed Preferences/");
+    sem = dispatch_semaphore_create(0);
+    FSEventStreamContext context = {0, &sem, NULL, NULL, NULL};
+    stream = FSEventStreamCreate(NULL,
+                               &fsevents_callback,
+                               &context,
+                               CFArrayCreate(NULL, (const void **)&path, 1, NULL),
+                               kFSEventStreamEventIdSinceNow,
+                               1.0,
+                               kFSEventStreamCreateFlagFileEvents);
+
+    dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
+    FSEventStreamSetDispatchQueue(stream, queue);
+    FSEventStreamStart(stream);
+
+    while (!disposed)
+    {
+        updatedPolicies.clear();
+        for (auto &policy : policies)
+        {
+            if (policy->refresh())
+            {
+                updatedPolicies.push_back(policy.get());
+            }
+        }
+
+        if (first || updatedPolicies.size() > 0)    
+            progress.Send(&updatedPolicies[0], updatedPolicies.size());
+
+        first = false;
+        dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER);
+    }
+}
+
+void PolicyWatcher::OnProgress(const Policy *const *policies, size_t count) 
+{
+  HandleScope scope(Env());
+  auto result = Object::New(Env());
+
+  for (size_t i = 0; i < count; i++)
+    result.Set(policies[i]->name, policies[i]->getValue(Env()));
+
+  Callback().Call(Receiver().Value(), {result});
+}
+
+void PolicyWatcher::Dispose() 
+{
+    disposed = true;
+    if (sem) {
+        dispatch_semaphore_signal(sem);
+    }
+}

--- a/src/macos/PreferencesPolicy.hh
+++ b/src/macos/PreferencesPolicy.hh
@@ -1,0 +1,62 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+#ifndef PREFERENCES_POLICY_H
+#define PREFERENCES_POLICY_H
+
+#include <napi.h>
+#include <CoreFoundation/CoreFoundation.h>
+#include "../Policy.hh"
+
+using namespace Napi;
+
+template <typename T>
+class PreferencesPolicy : public Policy
+{
+public:
+    PreferencesPolicy(const std::string name, const std::string &productName)
+        : Policy(name),
+        appID(CFStringCreateWithCString(NULL, productName.c_str(), kCFStringEncodingUTF8)),
+        key(CFStringCreateWithCString(NULL, name.c_str(), kCFStringEncodingUTF8))
+    {
+    }
+
+    ~PreferencesPolicy()
+    {
+        CFRelease(appID);
+        CFRelease(key);
+    }
+
+    bool refresh()
+    {
+        auto newValue = read();
+        if (newValue.has_value())
+        {
+            if (value != newValue)
+            {
+                value = newValue;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    Value getValue(Env env) const
+    {
+        if (!value.has_value())
+            return env.Undefined();
+        return getJSValue(env, *value);  // value.value() is only supported after macOS 10.13
+    }
+
+protected:
+    std::optional<T> value;
+    const CFStringRef appID;
+    const CFStringRef key;
+    virtual Value getJSValue(Env env, T value) const = 0;
+    virtual std::optional<T> read() const = 0;
+
+private:
+};
+#endif

--- a/src/macos/StringPolicy.cc
+++ b/src/macos/StringPolicy.cc
@@ -1,0 +1,46 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+#include "StringPolicy.hh"
+
+using namespace Napi;
+
+StringPolicy::StringPolicy(const std::string name, const std::string &productName)
+    : PreferencesPolicy(name, productName)
+{
+}
+
+Value StringPolicy::getJSValue(Env env, std::string value) const
+{
+  return String::New(env, value);
+}
+
+std::optional<std::string> StringPolicy::read() const
+{
+  auto pref = CFPreferencesCopyAppValue(key, appID);
+
+  if (pref == NULL)
+    return std::nullopt;
+
+  if (CFGetTypeID(pref) != CFStringGetTypeID())
+  {
+    CFRelease(pref);
+    return std::nullopt;
+  }
+
+  CFIndex length = CFStringGetLength((CFStringRef)pref);
+  CFIndex maxSize = CFStringGetMaximumSizeForEncoding(length, kCFStringEncodingUTF8) + 1;
+  std::vector<char> buffer(maxSize);
+
+  if (CFStringGetCString((CFStringRef)pref, buffer.data(), maxSize, kCFStringEncodingUTF8))
+  {
+    std::string result(buffer.data());
+    CFRelease(pref);
+    return result;
+  }
+
+  CFRelease(pref);
+  return std::nullopt;
+}

--- a/src/macos/StringPolicy.hh
+++ b/src/macos/StringPolicy.hh
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+#ifndef STRING_POLICY_H
+#define STRING_POLICY_H
+
+#include <napi.h>
+#include "PreferencesPolicy.hh"
+
+using namespace Napi;
+
+class StringPolicy : public PreferencesPolicy<std::string>
+{
+public:
+    StringPolicy(const std::string name, const std::string &productName);
+protected:
+    Value getJSValue(Env env, std::string value) const override;
+    std::optional<std::string> read() const override;
+};
+
+#endif

--- a/src/main.cc
+++ b/src/main.cc
@@ -22,7 +22,7 @@ Value CreateWatcher(const CallbackInfo &info)
 {
   auto env = info.Env();
 
-#ifndef WINDOWS
+#if !defined(WINDOWS) && !defined(MACOS)
   throw TypeError::New(env, "Unsupported platform");
 #endif
 
@@ -55,18 +55,22 @@ Value CreateWatcher(const CallbackInfo &info)
 
     auto policyType = std::string(rawPolicyType.As<String>());
 
-    if (policyType == "string")
+    if (policyType == "string") {
       watcher->AddStringPolicy(rawPolicyName.As<String>());
-    else if (policyType == "number")
+    }
+    else if (policyType == "number") {
       watcher->AddNumberPolicy(rawPolicyName.As<String>());
-    else
+    }
+    else {
       throw TypeError::New(env, "Unknown policy type '" + policyType + "'");
+    }
   }
 
   watcher->Queue();
 
   auto result = Object::New(env);
   result.Set(String::New(env, "dispose"), Function::New(env, DisposeWatcher, "disposeWatcher", watcher));
+
   return result;
 }
 


### PR DESCRIPTION
ref: https://github.com/microsoft/vscode/issues/148942

Utilizes macOS's [PreferencesUtilties](https://developer.apple.com/documentation/preferences/preferences_utilities) to pick up settings for VS Code that have been configured via a configuration profile.

This strategy appears to be aligned with other project's implementations, like [tailscale](https://tailscale.com/kb/1286/macos-mdm) and [brave](https://support.brave.com/hc/en-us/articles/360039248271-Group-Policy)


## Testing

To try this out e2e:

- Checkout OSS from https://github.com/microsoft/vscode/tree/joshspicer/mac-policy
- Checkout this repo
- In OSS root: `npm link <path-to-this-repo>`
- F5

You'll then want to get yourself a `.mobileconfig` file.  These can be installed in System Preferences under `General > Device Management`.  

You can customize a profile in two ways:

1. Use the 'iMazing' program ([use my branch to leverage this schema i've written](https://github.com/joshspicer/ProfileManifests/pull/1))
2. Customize the file below and save with extension `.mobileconfig`

```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
        <key>ConsentText</key>
        <dict>
                <key>default</key>
                <string>This profile manages VS Code (OSS) settings</string>
        </dict>
        <key>PayloadContent</key>
        <array>
                <dict>
                        <key>AllowedExtensions</key>
                        <string>{"github": true, "joshspicer": true, "ms-vscode-remote.remote-ssh": true}</string>
                        <key>PayloadDisplayName</key>
                        <string>Code (OSS)</string>
                        <key>PayloadIdentifier</key>
                        <string>com.visualstudio.code.oss.3AD1E08A-673E-4C62-AA68-D43ED8180249</string>
                        <key>PayloadType</key>
                        <string>com.visualstudio.code.oss</string>
                        <key>PayloadUUID</key>
                        <string>3AD1E08A-673E-4C62-AA68-D43ED8180249</string>
                        <key>PayloadVersion</key>
                        <integer>1</integer>
                        <key>UpdateMode</key>
                        <string>manual</string>
                </dict>
        </array>
        <key>PayloadDescription</key>
        <string>To administer potentially sensitive VS Code settings</string>
        <key>PayloadDisplayName</key>
        <string>Code OSS (Test)</string>
        <key>PayloadIdentifier</key>
        <string>com.visualstudio.code.oss</string>
        <key>PayloadOrganization</key>
        <string>Microsoft</string>
        <key>PayloadType</key>
        <string>Configuration</string>
        <key>PayloadUUID</key>
        <string>9F957DE8-6596-4CD6-A54E-D3A20F2B1C37</string>
        <key>PayloadVersion</key>
        <integer>1</integer>
        <key>TargetDeviceType</key>
        <integer>5</integer>
</dict>
</plist>
```