### PR TITLE
React to removing configuration

### DIFF
--- a/src/Policy.hh
+++ b/src/Policy.hh
@@ -10,11 +10,18 @@
 
 using namespace Napi;
 
+enum class PolicyRefreshResult {
+  Updated,
+  Unchanged,
+  Removed,
+  NotSet
+};
+
 class Policy
 {
 public:
   virtual ~Policy() {}
-  virtual bool refresh() = 0;
+  virtual PolicyRefreshResult refresh() = 0;
   virtual Value getValue(Env env) const = 0;
   const std::string name;
 

--- a/src/macos/PolicyWatcher.cc
+++ b/src/macos/PolicyWatcher.cc
@@ -80,15 +80,27 @@ void PolicyWatcher::Execute(const ExecutionProgress &progress)
     while (!disposed)
     {
         updatedPolicies.clear();
+        bool update = false;
         for (auto &policy : policies)
-        {
-            if (policy->refresh())
+        {            
+            switch(policy->refresh())
             {
-                updatedPolicies.push_back(policy.get());
+                case PolicyRefreshResult::Updated:
+                    updatedPolicies.push_back(policy.get());
+                    update = true;
+                    break;
+                case PolicyRefreshResult::Unchanged:
+                    updatedPolicies.push_back(policy.get());
+                    break;
+                case PolicyRefreshResult::Removed:
+                    update = true;
+                    break;
+                case PolicyRefreshResult::NotSet:
+                    break;
             }
         }
 
-        if (first || updatedPolicies.size() > 0)    
+        if (first || update)
             progress.Send(&updatedPolicies[0], updatedPolicies.size());
 
         first = false;
@@ -100,6 +112,12 @@ void PolicyWatcher::OnProgress(const Policy *const *policies, size_t count)
 {
   HandleScope scope(Env());
   auto result = Object::New(Env());
+
+  if (count == 0)
+  {
+    Callback().Call(Receiver().Value(), {result});
+    return;
+  }
 
   for (size_t i = 0; i < count; i++)
     result.Set(policies[i]->name, policies[i]->getValue(Env()));

--- a/src/macos/PolicyWatcher.cc
+++ b/src/macos/PolicyWatcher.cc
@@ -71,7 +71,7 @@ void PolicyWatcher::Execute(const ExecutionProgress &progress)
                                CFArrayCreate(NULL, (const void **)&path, 1, NULL),
                                kFSEventStreamEventIdSinceNow,
                                1.0,
-                               kFSEventStreamCreateFlagFileEvents);
+                               kCFStreamEventNone);
 
     dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
     FSEventStreamSetDispatchQueue(stream, queue);

--- a/src/macos/PolicyWatcher.cc
+++ b/src/macos/PolicyWatcher.cc
@@ -95,8 +95,6 @@ void PolicyWatcher::Execute(const ExecutionProgress &progress)
                 case PolicyRefreshResult::Removed:
                     update = true;
                     break;
-                case PolicyRefreshResult::NotSet:
-                    break;
             }
         }
 

--- a/src/macos/PreferencesPolicy.hh
+++ b/src/macos/PreferencesPolicy.hh
@@ -33,25 +33,21 @@ public:
     {
         auto newValue = read();
 
-        // Value not set
-        if (!value.has_value() && !newValue.has_value())
-            return PolicyRefreshResult::NotSet;
-
-        // Value previously set, now removed
-        if (value.has_value() && !newValue.has_value())
+        // Check for no value or removal
+        if (!newValue.has_value())
         {
+            if (!value.has_value())
+                return PolicyRefreshResult::NotSet;
+
             value.reset();
             return PolicyRefreshResult::Removed;
         }
 
-        // New value
-        if (newValue.has_value())
+        // Is the value updated?
+        if (value != newValue)
         {
-            if (value != newValue)
-            {
-                value = newValue;
-                return PolicyRefreshResult::Updated;
-            }
+            value = newValue;
+            return PolicyRefreshResult::Updated;
         }
 
         return PolicyRefreshResult::Unchanged;

--- a/src/windows/PolicyWatcher.cc
+++ b/src/windows/PolicyWatcher.cc
@@ -63,15 +63,26 @@ void PolicyWatcher::Execute(const ExecutionProgress &progress)
   {
     std::vector<const Policy *> updatedPolicies;
 
+    bool update = false;
+    updatedPolicies.clear();
     for (auto &policy : policies)
     {
-      if (policy->refresh())
+      switch (policy->refresh())
       {
+      case PolicyRefreshResult::Updated:
         updatedPolicies.push_back(policy.get());
+        update = true;
+        break;
+      case PolicyRefreshResult::Unchanged:
+        updatedPolicies.push_back(policy.get());
+        break;
+      case PolicyRefreshResult::Removed:
+        update = true;
+        break;
       }
     }
 
-    if (first || updatedPolicies.size() > 0)
+    if (first || update)
       progress.Send(&updatedPolicies[0], updatedPolicies.size());
 
     first = false;


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode-policy-watcher/issues/47

On both Windows and MacOS the watcher does not respond to removing configuration (requires a reload of VS Code).  This change ensures that removing configuration is also reflected back 

~TODO: Mirror this on the windows side~