### PR TITLE
Add BooleanPolicy

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -17,7 +17,8 @@
                     "sources": [
                         "src/macos/PolicyWatcher.cc",
                         "src/macos/StringPolicy.cc",
-                        "src/macos/NumberPolicy.cc"
+                        "src/macos/NumberPolicy.cc",
+                        "src/macos/BooleanPolicy.cc"
                     ],
                     "defines": [
                         "MACOS",
@@ -40,7 +41,8 @@
                     "sources": [
                         "src/windows/PolicyWatcher.cc",
                         "src/windows/StringPolicy.cc",
-                        "src/windows/NumberPolicy.cc"
+                        "src/windows/NumberPolicy.cc",
+                        "src/windows/BooleanPolicy.cc"
                     ],
                     "defines": [
                         "WINDOWS"

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,9 +9,10 @@ interface Watcher {
 
 type StringPolicy = { type: "string" };
 type NumberPolicy = { type: "number" };
+type BooleanPolicy = { type: "boolean" };
 
 export interface Policies {
-  [policyName: string]: StringPolicy | NumberPolicy;
+  [policyName: string]: StringPolicy | NumberPolicy | BooleanPolicy;
 }
 
 export type PolicyUpdate<T extends Policies> = {
@@ -19,9 +20,11 @@ export type PolicyUpdate<T extends Policies> = {
     | undefined
     | (T[K] extends StringPolicy
         ? string
+        : (T[K] extends BooleanPolicy
+        ? boolean
         : T[K] extends NumberPolicy
         ? number
-        : never);
+        : never));
 };
 
 export function createWatcher<T extends Policies>(

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ if (require.main === module) {
     {
       UpdateMode: { type: 'string' },
       SCMInputFontSize: { type: 'number' },
+      DisableFeedback: { type: 'boolean' },
     },
     msg => console.log(msg)
   );

--- a/src/PolicyWatcher.hh
+++ b/src/PolicyWatcher.hh
@@ -29,6 +29,7 @@ public:
 
   void AddStringPolicy(const std::string name);
   void AddNumberPolicy(const std::string name);
+  void AddBooleanPolicy(const std::string name);
 
   void OnExecute(Napi::Env env);
   void Execute(const ExecutionProgress &progress);

--- a/src/linux/PolicyWatcher.cc
+++ b/src/linux/PolicyWatcher.cc
@@ -19,6 +19,7 @@ PolicyWatcher::~PolicyWatcher()
 
 void PolicyWatcher::AddStringPolicy(const std::string name) {}
 void PolicyWatcher::AddNumberPolicy(const std::string name) {}
+void PolicyWatcher::AddBooleanPolicy(const std::string name) {}
 void PolicyWatcher::OnExecute(Napi::Env env) {}
 void PolicyWatcher::Execute(const ExecutionProgress &progress) {}
 void PolicyWatcher::OnProgress(const Policy *const *policies, size_t count) {}

--- a/src/macos/BooleanPolicy.cc
+++ b/src/macos/BooleanPolicy.cc
@@ -1,0 +1,36 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+#include "BooleanPolicy.hh"
+
+using namespace Napi;
+
+BooleanPolicy::BooleanPolicy(const std::string name, const std::string &productName)
+    : PreferencesPolicy(name, productName)
+{
+}
+
+Value BooleanPolicy::getJSValue(Env env, bool value) const
+{
+  return Napi::Boolean::New(env, value);
+}
+
+std::optional<bool> BooleanPolicy::read() const
+{
+  auto pref = CFPreferencesCopyAppValue(key, appID);
+
+  if (pref == NULL)
+    return std::nullopt;
+
+  if (CFGetTypeID(pref) != CFBooleanGetTypeID())
+  {
+    CFRelease(pref);
+    return std::nullopt;
+  }
+
+  bool value = (pref == kCFBooleanTrue);
+  CFRelease(pref);
+  return value;
+}

--- a/src/macos/BooleanPolicy.hh
+++ b/src/macos/BooleanPolicy.hh
@@ -1,0 +1,24 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+#ifndef MAC_BOOLEAN_POLICY_H
+#define MAC_BOOLEAN_POLICY_H
+
+#include <napi.h>
+#include "PreferencesPolicy.hh"
+
+using namespace Napi;
+
+class BooleanPolicy : public PreferencesPolicy<bool>
+{
+public:
+  BooleanPolicy(const std::string name, const std::string &productName);
+  std::optional<bool> read() const override;
+
+protected:
+  Value getJSValue(Env env, bool value) const override;
+};
+
+#endif

--- a/src/macos/PolicyWatcher.cc
+++ b/src/macos/PolicyWatcher.cc
@@ -6,6 +6,7 @@
 #include "../PolicyWatcher.hh"
 #include "StringPolicy.hh"
 #include "NumberPolicy.hh"
+#include "BooleanPolicy.hh"
 #include <thread>
 
 using namespace Napi;
@@ -49,6 +50,11 @@ void PolicyWatcher::AddStringPolicy(const std::string name)
 void PolicyWatcher::AddNumberPolicy(const std::string name)
 {
     policies.push_back(std::make_unique<NumberPolicy>(name, productName));
+}
+
+void PolicyWatcher::AddBooleanPolicy(const std::string name)
+{
+    policies.push_back(std::make_unique<BooleanPolicy>(name, productName));
 }
 
 void PolicyWatcher::OnExecute(Napi::Env env)

--- a/src/main.cc
+++ b/src/main.cc
@@ -60,8 +60,9 @@ Value CreateWatcher(const CallbackInfo &info)
     }
     else if (policyType == "number") {
       watcher->AddNumberPolicy(rawPolicyName.As<String>());
-    }
-    else {
+    } else if (policyType == "boolean") {
+      watcher->AddBooleanPolicy(rawPolicyName.As<String>());
+    } else {
       throw TypeError::New(env, "Unknown policy type '" + policyType + "'");
     }
   }

--- a/src/windows/BooleanPolicy.cc
+++ b/src/windows/BooleanPolicy.cc
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+#include "BooleanPolicy.hh"
+
+using namespace Napi;
+
+BooleanPolicy::BooleanPolicy(const std::string& name, const std::string& productName)
+    : RegistryPolicy(name, productName, {REG_QWORD}) {}
+
+long long BooleanPolicy::parseRegistryValue(LPBYTE buffer, DWORD bufferSize, DWORD type) const
+{
+  // TODO: Unimplemented
+  return 0; 
+}
+
+Value BooleanPolicy::getJSValue(Env env, long long value) const
+{
+  return Boolean::New(env, static_cast<bool>(value));
+}

--- a/src/windows/BooleanPolicy.cc
+++ b/src/windows/BooleanPolicy.cc
@@ -4,19 +4,25 @@
  *--------------------------------------------------------------------------------------------*/
 
 #include "BooleanPolicy.hh"
+#include <iostream>
 
 using namespace Napi;
 
 BooleanPolicy::BooleanPolicy(const std::string& name, const std::string& productName)
-    : RegistryPolicy(name, productName, {REG_QWORD}) {}
+  : RegistryPolicy(name, productName, {REG_DWORD}) {}
 
-long long BooleanPolicy::parseRegistryValue(LPBYTE buffer, DWORD bufferSize, DWORD type) const
+bool BooleanPolicy::parseRegistryValue(LPBYTE buffer, DWORD bufferSize, DWORD type) const
 {
-  // TODO: Unimplemented
-  return 0; 
+  if (type != REG_DWORD || bufferSize != sizeof(DWORD))
+  {
+    return false;
+  }
+
+  DWORD value = *reinterpret_cast<DWORD*>(buffer);
+  return (value != 0);
 }
 
-Value BooleanPolicy::getJSValue(Env env, long long value) const
+Value BooleanPolicy::getJSValue(Env env, bool value) const
 {
-  return Boolean::New(env, static_cast<bool>(value));
+  return Boolean::New(env, value);
 }

--- a/src/windows/BooleanPolicy.hh
+++ b/src/windows/BooleanPolicy.hh
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+#ifndef BOOLEAN_POLICY_H
+#define BOOLEAN_POLICY_H
+
+#include <napi.h>
+#include <windows.h>
+#include "RegistryPolicy.hh"
+
+using namespace Napi;
+
+class BooleanPolicy : public RegistryPolicy<long long>
+{
+public:
+  BooleanPolicy(const std::string& name, const std::string &productName);
+
+protected:
+  long long parseRegistryValue(LPBYTE buffer, DWORD bufferSize, DWORD type) const;
+  Value getJSValue(Env env, long long value) const;
+};
+
+#endif

--- a/src/windows/BooleanPolicy.hh
+++ b/src/windows/BooleanPolicy.hh
@@ -12,14 +12,14 @@
 
 using namespace Napi;
 
-class BooleanPolicy : public RegistryPolicy<long long>
+class BooleanPolicy : public RegistryPolicy<bool>
 {
 public:
   BooleanPolicy(const std::string& name, const std::string &productName);
 
 protected:
-  long long parseRegistryValue(LPBYTE buffer, DWORD bufferSize, DWORD type) const;
-  Value getJSValue(Env env, long long value) const;
+  bool parseRegistryValue(LPBYTE buffer, DWORD bufferSize, DWORD type) const;
+  Value getJSValue(Env env, bool value) const;
 };
 
 #endif

--- a/src/windows/PolicyWatcher.cc
+++ b/src/windows/PolicyWatcher.cc
@@ -8,6 +8,7 @@
 #include "../PolicyWatcher.hh"
 #include "StringPolicy.hh"
 #include "NumberPolicy.hh"
+#include "BooleanPolicy.hh"
 
 using namespace Napi;
 
@@ -35,6 +36,11 @@ void PolicyWatcher::AddStringPolicy(const std::string name)
 void PolicyWatcher::AddNumberPolicy(const std::string name)
 {
   policies.push_back(std::make_unique<NumberPolicy>(name, productName));
+}
+
+void PolicyWatcher::AddBooleanPolicy(const std::string name)
+{
+  policies.push_back(std::make_unique<BooleanPolicy>(name, productName));
 }
 
 void PolicyWatcher::OnExecute(Napi::Env env)


### PR DESCRIPTION
ref https://github.com/microsoft/vscode-internalbacklog/issues/5375

Add policywatcher support for boolean policy, as added into VS Code with https://github.com/microsoft/vscode/pull/243276


- [x] Windows

https://github.com/user-attachments/assets/f7f4d08a-bba7-4e8f-8317-2276fd83e097


- [x] macOS

https://github.com/user-attachments/assets/3f647c91-78aa-4ae8-8d2c-1a3432b2fa9b


