### PR TITLE
Emit 'undefined' value for removed policy 

### DIFF
--- a/src/macos/PolicyWatcher.cc
+++ b/src/macos/PolicyWatcher.cc
@@ -92,14 +92,12 @@ void PolicyWatcher::Execute(const ExecutionProgress &progress)
             switch(policy->refresh())
             {
                 case PolicyRefreshResult::Updated:
+                case PolicyRefreshResult::Removed:
                     updatedPolicies.push_back(policy.get());
                     update = true;
                     break;
                 case PolicyRefreshResult::Unchanged:
                     updatedPolicies.push_back(policy.get());
-                    break;
-                case PolicyRefreshResult::Removed:
-                    update = true;
                     break;
             }
         }

--- a/src/windows/PolicyWatcher.cc
+++ b/src/windows/PolicyWatcher.cc
@@ -76,14 +76,12 @@ void PolicyWatcher::Execute(const ExecutionProgress &progress)
       switch (policy->refresh())
       {
       case PolicyRefreshResult::Updated:
+      case PolicyRefreshResult::Removed:
         updatedPolicies.push_back(policy.get());
         update = true;
         break;
       case PolicyRefreshResult::Unchanged:
         updatedPolicies.push_back(policy.get());
-        break;
-      case PolicyRefreshResult::Removed:
-        update = true;
         break;
       }
     }


### PR DESCRIPTION
ref https://github.com/microsoft/vscode/issues/244997

Upon removing a configuration profile, the value of the policy is `undefined` instead of it being omitted from the output object:

### Mac (adding and remove configuration profile)
<img width="265" alt="image" src="https://github.com/user-attachments/assets/083c5a9d-3391-4128-aec6-71b2f970c041" />

### Windows (toggling in the GP editor)

<img width="551" alt="image" src="https://github.com/user-attachments/assets/0bad670b-8b13-49db-b1a4-5b76f08b24bd" />


This aligns with the expectations in [vs code](https://github.com/microsoft/vscode/blob/4ef91ef990b8dfee1c8d4c00cb95790d2b626ff9/src/vs/platform/policy/node/nativePolicyService.ts#L46-L54)


https://github.com/user-attachments/assets/b41778c2-2b23-4ed6-87ef-fa2d31d4af7c

