### PR TITLE
1.3.7

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -24,7 +24,7 @@
                         "MACOS",
                     ],
                     "cflags": [
-                        "-O2", "-D_FORTIFY_SOURCE=2", "-fstack-protector-strong"
+                        "-O2", "-fstack-protector-strong"
                     ]
                 }],
                 ['OS=="mac" and target_arch=="arm64"', {
@@ -40,7 +40,7 @@
                         "LINUX",
                     ],
                     "cflags": [
-                        "-O2", "-D_FORTIFY_SOURCE=2", "-fstack-protector-strong"
+                        "-O2", "-fstack-protector-strong"
                     ]
                 }],
                 ["OS=='win'", {

--- a/binding.gyp
+++ b/binding.gyp
@@ -24,7 +24,7 @@
                         "MACOS",
                     ],
                     "cflags": [
-                        "-O2", "-D_FORTIFY_SOURCE=2"
+                        "-O2", "-D_FORTIFY_SOURCE=2", "-fstack-protector-strong"
                     ]
                 }],
                 ['OS=="mac" and target_arch=="arm64"', {
@@ -40,7 +40,7 @@
                         "LINUX",
                     ],
                     "cflags": [
-                        "-O2", "-D_FORTIFY_SOURCE=2"
+                        "-O2", "-D_FORTIFY_SOURCE=2", "-fstack-protector-strong"
                     ]
                 }],
                 ["OS=='win'", {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vscode/policy-watcher",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vscode/policy-watcher",
-      "version": "1.3.6",
+      "version": "1.3.7",
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vscode/policy-watcher",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
This PR adds a stack-protector-strong flag to the library. I confirmed that the binary grows by under 100 bytes. Also, I do not believe that VS Code calls into the binary enough to warrant performance testing.