### PR TITLE
feat: make Windows registry path prefix configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,23 @@ createWatcher(
 );
 ```
 
+### Options
+
+An optional fourth argument can be passed to configure platform-specific behavior:
+
+```js
+createWatcher(
+  "MyApp",
+  { UpdateMode: { type: "string" } },
+  (update) => console.log(update),
+  { registryPathPrefix: "" }  // Software\Policies\MyApp
+);
+```
+
+| Option | Default | Description |
+|---|---|---|
+| `registryPathPrefix` | `"Microsoft"` | Prefix inserted before the product name in the registry path. Default results in `Software\Policies\Microsoft\{productName}`. Set to `""` for `Software\Policies\{productName}`. |
+
 ## Contributing
 
 This project welcomes contributions and suggestions. Most contributions require you to agree to a

--- a/index.d.ts
+++ b/index.d.ts
@@ -27,8 +27,18 @@ export type PolicyUpdate<T extends Policies> = {
         : never));
 };
 
+export interface WatcherOptions {
+  /**
+   * Sets the registry path prefix before the product name.
+   * Defaults to `"Microsoft"`, resulting in `Software\Policies\Microsoft\{productName}`.
+   * Set to `""` for `Software\Policies\{productName}`.
+   */
+  registryPathPrefix?: string;
+}
+
 export function createWatcher<T extends Policies>(
   productName: string,
   policies: T,
-  onDidChange: (update: PolicyUpdate<T>) => void
+  onDidChange: (update: PolicyUpdate<T>) => void,
+  options?: WatcherOptions
 ): Watcher;

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ if (require.main === module) {
       SCMInputFontSize: { type: 'number' },
       DisableFeedback: { type: 'boolean' },
     },
-    msg => console.log(msg)
+    msg => console.log(msg),
+    { registryPathPrefix: 'Microsoft' }  // Software\Policies\Microsoft\CodeOSS
   );
 }

--- a/src/PolicyWatcher.hh
+++ b/src/PolicyWatcher.hh
@@ -24,7 +24,7 @@ using namespace Napi;
 class PolicyWatcher : public AsyncProgressQueueWorker<const Policy *>
 {
 public:
-  PolicyWatcher(std::string productName, const Function &okCallback);
+  PolicyWatcher(std::string productName, const Function &okCallback, std::string registryPathPrefix = "Microsoft");
   ~PolicyWatcher();
 
   void AddStringPolicy(const std::string name);
@@ -39,6 +39,7 @@ public:
 
 protected:
   std::string productName;
+  std::string registryPathPrefix;
   std::vector<std::unique_ptr<Policy>> policies;
 
 #ifdef WINDOWS

--- a/src/macos/PolicyWatcher.cc
+++ b/src/macos/PolicyWatcher.cc
@@ -22,9 +22,10 @@ static void fsevents_callback(ConstFSEventStreamRef streamRef,
     dispatch_semaphore_signal(*sem);
 }
 
-PolicyWatcher::PolicyWatcher(std::string productName, const Function &okCallback)
+PolicyWatcher::PolicyWatcher(std::string productName, const Function &okCallback, std::string registryPathPrefix)
     : AsyncProgressQueueWorker(okCallback),
       productName(productName),
+      registryPathPrefix(registryPathPrefix),
       stream(nullptr),
       sem(nullptr),
       disposed(false)

--- a/src/main.cc
+++ b/src/main.cc
@@ -27,7 +27,7 @@ Value CreateWatcher(const CallbackInfo &info)
 #endif
 
   if (info.Length() < 3)
-    throw TypeError::New(env, "Expected 3 arguments");
+    throw TypeError::New(env, "Expected at least 3 arguments");
   else if (!info[0].IsString())
     throw TypeError::New(env, "Expected first arg to be string");
   else if (!info[1].IsObject())
@@ -35,9 +35,22 @@ Value CreateWatcher(const CallbackInfo &info)
   else if (!info[2].IsFunction())
     throw TypeError::New(env, "Expected third arg to be function");
 
+  // Parse optional 4th argument: options object
+  std::string registryPathPrefix = "Microsoft";
+  if (info.Length() >= 4 && info[3].IsObject())
+  {
+    auto options = info[3].As<Object>();
+    if (options.Has("registryPathPrefix"))
+    {
+      auto prefixValue = options.Get("registryPathPrefix");
+      if (prefixValue.IsString())
+        registryPathPrefix = prefixValue.As<String>().Utf8Value();
+    }
+  }
+
   auto rawPolicies = info[1].As<Object>();
   auto policies = std::vector<std::unique_ptr<Policy>>();
-  auto watcher = new PolicyWatcher(info[0].As<String>(), info[2].As<Function>());
+  auto watcher = new PolicyWatcher(info[0].As<String>(), info[2].As<Function>(), registryPathPrefix);
 
   for (auto const &item : rawPolicies)
   {

--- a/src/windows/BooleanPolicy.cc
+++ b/src/windows/BooleanPolicy.cc
@@ -8,8 +8,8 @@
 
 using namespace Napi;
 
-BooleanPolicy::BooleanPolicy(const std::string& name, const std::string& productName)
-  : RegistryPolicy(name, productName, {REG_DWORD}) {}
+BooleanPolicy::BooleanPolicy(const std::string& name, const std::string& productName, const std::string& registryPathPrefix)
+  : RegistryPolicy(name, productName, registryPathPrefix, {REG_DWORD}) {}
 
 bool BooleanPolicy::parseRegistryValue(LPBYTE buffer, DWORD bufferSize, DWORD type) const
 {

--- a/src/windows/BooleanPolicy.hh
+++ b/src/windows/BooleanPolicy.hh
@@ -15,7 +15,7 @@ using namespace Napi;
 class BooleanPolicy : public RegistryPolicy<bool>
 {
 public:
-  BooleanPolicy(const std::string& name, const std::string &productName);
+  BooleanPolicy(const std::string& name, const std::string &productName, const std::string &registryPathPrefix = "Microsoft");
 
 protected:
   bool parseRegistryValue(LPBYTE buffer, DWORD bufferSize, DWORD type) const;

--- a/src/windows/NumberPolicy.cc
+++ b/src/windows/NumberPolicy.cc
@@ -7,8 +7,8 @@
 
 using namespace Napi;
 
-NumberPolicy::NumberPolicy(const std::string name, const std::string &productName)
-    : RegistryPolicy(name, productName, {REG_QWORD}) {}
+NumberPolicy::NumberPolicy(const std::string name, const std::string &productName, const std::string &registryPathPrefix)
+    : RegistryPolicy(name, productName, registryPathPrefix, {REG_QWORD}) {}
 
 long long NumberPolicy::parseRegistryValue(LPBYTE buffer, DWORD bufferSize, DWORD type) const
 {

--- a/src/windows/NumberPolicy.hh
+++ b/src/windows/NumberPolicy.hh
@@ -15,7 +15,7 @@ using namespace Napi;
 class NumberPolicy : public RegistryPolicy<long long>
 {
 public:
-  NumberPolicy(const std::string name, const std::string &productName);
+  NumberPolicy(const std::string name, const std::string &productName, const std::string &registryPathPrefix = "Microsoft");
 
 protected:
   long long parseRegistryValue(LPBYTE buffer, DWORD bufferSize, DWORD type) const;

--- a/src/windows/PolicyWatcher.cc
+++ b/src/windows/PolicyWatcher.cc
@@ -12,9 +12,10 @@
 
 using namespace Napi;
 
-PolicyWatcher::PolicyWatcher(std::string productName, const Function &okCallback)
+PolicyWatcher::PolicyWatcher(std::string productName, const Function &okCallback, std::string registryPathPrefix)
     : AsyncProgressQueueWorker(okCallback),
-      productName(productName)
+      productName(productName),
+      registryPathPrefix(registryPathPrefix)
 {
 }
 
@@ -30,17 +31,17 @@ PolicyWatcher::~PolicyWatcher()
 
 void PolicyWatcher::AddStringPolicy(const std::string name)
 {
-  policies.push_back(std::make_unique<StringPolicy>(name, productName));
+  policies.push_back(std::make_unique<StringPolicy>(name, productName, registryPathPrefix));
 }
 
 void PolicyWatcher::AddNumberPolicy(const std::string name)
 {
-  policies.push_back(std::make_unique<NumberPolicy>(name, productName));
+  policies.push_back(std::make_unique<NumberPolicy>(name, productName, registryPathPrefix));
 }
 
 void PolicyWatcher::AddBooleanPolicy(const std::string name)
 {
-  policies.push_back(std::make_unique<BooleanPolicy>(name, productName));
+  policies.push_back(std::make_unique<BooleanPolicy>(name, productName, registryPathPrefix));
 }
 
 void PolicyWatcher::OnExecute(Napi::Env env)

--- a/src/windows/RegistryPolicy.hh
+++ b/src/windows/RegistryPolicy.hh
@@ -19,9 +19,9 @@ template <typename T>
 class RegistryPolicy : public Policy
 {
 public:
-  RegistryPolicy(const std::string name, const std::string &productName, const std::vector<DWORD>& types)
+  RegistryPolicy(const std::string name, const std::string &productName, const std::string &registryPathPrefix, const std::vector<DWORD>& types)
       : Policy(name),
-        registryKey("Software\\Policies\\Microsoft\\" + productName),
+        registryKey("Software\\Policies\\" + (registryPathPrefix.empty() ? "" : registryPathPrefix + "\\") + productName),
         supportedTypes(types) {}
 
   PolicyRefreshResult refresh()

--- a/src/windows/StringPolicy.cc
+++ b/src/windows/StringPolicy.cc
@@ -7,8 +7,8 @@
 
 using namespace Napi;
 
-StringPolicy::StringPolicy(const std::string name, const std::string &productName)
-    : RegistryPolicy(name, productName, {REG_SZ, REG_MULTI_SZ}) {}
+StringPolicy::StringPolicy(const std::string name, const std::string &productName, const std::string &registryPathPrefix)
+    : RegistryPolicy(name, productName, registryPathPrefix, {REG_SZ, REG_MULTI_SZ}) {}
 
 std::string StringPolicy::parseRegistryValue(LPBYTE buffer, DWORD bufferSize, DWORD type) const
 {

--- a/src/windows/StringPolicy.hh
+++ b/src/windows/StringPolicy.hh
@@ -15,7 +15,7 @@ using namespace Napi;
 class StringPolicy : public RegistryPolicy<std::string>
 {
 public:
-  StringPolicy(const std::string name, const std::string &productName);
+  StringPolicy(const std::string name, const std::string &productName, const std::string &registryPathPrefix = "Microsoft");
 
 protected:
   std::string parseRegistryValue(LPBYTE buffer, DWORD bufferSize, DWORD type) const;


### PR DESCRIPTION
## Problem

The Windows registry path is hardcoded to `Software\Policies\Microsoft\{productName}`. VS Code forks that ship under a different organization cannot use their own registry namespace without forking this module.

## Solution

Add an optional `registryPathPrefix` option to `createWatcher`:

```js
// Default (backward compatible) — Software\Policies\Microsoft\{productName}
createWatcher('MyApp', policies, callback);

// No prefix — Software\Policies\{productName}
createWatcher('MyApp', policies, callback, { registryPathPrefix: '' });

// Custom prefix — Software\Policies\Custom\{productName}
createWatcher('MyApp', policies, callback, { registryPathPrefix: 'Custom' });
```

## Changes

- `index.d.ts`: Added `WatcherOptions` interface with `registryPathPrefix`, added optional 4th parameter to `createWatcher`
- `src/main.cc`: Parse the options object and pass prefix to `PolicyWatcher`
- `src/windows/RegistryPolicy.hh`: Use the prefix instead of hardcoded `Microsoft`
- `src/windows/PolicyWatcher.cc`: Store and pass prefix to policy constructors
- `src/windows/{String,Number,Boolean}Policy.{hh,cc}`: Accept and forward prefix
- `src/PolicyWatcher.hh`: Added `registryPathPrefix` member
- `src/macos/PolicyWatcher.cc`: Accept new constructor parameter (unused on macOS)
- `README.md`, `index.js`: Updated docs and example

## Backward Compatibility

Fully backward compatible. When no options are passed, the default prefix is `"Microsoft"`, preserving the existing behavior. All existing callers continue to work without changes.