### PR TITLE
feat: custom registry path support for policy watchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ createWatcher(
 );
 ```
 
+On Windows, you can optionally pass `{ registryPath: 'Software\\Policies\\GitHubCopilot' }` as a fourth argument to watch a custom registry root.
+
 ## Contributing
 
 This project welcomes contributions and suggestions. Most contributions require you to agree to a

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,6 +15,11 @@ export interface Policies {
   [policyName: string]: StringPolicy | NumberPolicy | BooleanPolicy;
 }
 
+export interface WatcherOptions {
+  /** Windows only: custom registry key path. Defaults to `Software\Policies\Microsoft\<productName>`. */
+  registryPath?: string;
+}
+
 export type PolicyUpdate<T extends Policies> = {
   [K in keyof T]:
     | undefined
@@ -30,5 +35,6 @@ export type PolicyUpdate<T extends Policies> = {
 export function createWatcher<T extends Policies>(
   productName: string,
   policies: T,
-  onDidChange: (update: PolicyUpdate<T>) => void
+  onDidChange: (update: PolicyUpdate<T>) => void,
+  options?: WatcherOptions
 ): Watcher;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vscode/policy-watcher",
-  "version": "1.3.7",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vscode/policy-watcher",
-      "version": "1.3.7",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vscode/policy-watcher",
-  "version": "1.3.7",
+  "version": "1.4.0",
   "description": "",
   "main": "index.js",
   "repository": {

--- a/src/PolicyWatcher.hh
+++ b/src/PolicyWatcher.hh
@@ -25,6 +25,11 @@ class PolicyWatcher : public AsyncProgressQueueWorker<const Policy *>
 {
 public:
   PolicyWatcher(std::string productName, const Function &okCallback);
+  PolicyWatcher(std::string productName, const Function &okCallback, std::string registryPath)
+      : PolicyWatcher(productName, okCallback)
+  {
+    this->registryPath = registryPath;
+  }
   ~PolicyWatcher();
 
   void AddStringPolicy(const std::string name);
@@ -39,6 +44,7 @@ public:
 
 protected:
   std::string productName;
+  std::string registryPath;
   std::vector<std::unique_ptr<Policy>> policies;
 
 #ifdef WINDOWS

--- a/src/main.cc
+++ b/src/main.cc
@@ -35,9 +35,27 @@ Value CreateWatcher(const CallbackInfo &info)
   else if (!info[2].IsFunction())
     throw TypeError::New(env, "Expected third arg to be function");
 
+  std::string registryPath;
+
+  if (info.Length() > 3 && !info[3].IsUndefined())
+  {
+    if (!info[3].IsObject())
+      throw TypeError::New(env, "Expected fourth arg to be object");
+
+    auto rawOptions = info[3].As<Object>();
+    auto rawRegistryPath = rawOptions.Get("registryPath");
+
+    if (!rawRegistryPath.IsUndefined())
+    {
+      if (!rawRegistryPath.IsString())
+        throw TypeError::New(env, "Expected options.registryPath to be string");
+
+      registryPath = rawRegistryPath.As<String>();
+    }
+  }
+
   auto rawPolicies = info[1].As<Object>();
-  auto policies = std::vector<std::unique_ptr<Policy>>();
-  auto watcher = new PolicyWatcher(info[0].As<String>(), info[2].As<Function>());
+  auto watcher = new PolicyWatcher(info[0].As<String>(), info[2].As<Function>(), registryPath);
 
   for (auto const &item : rawPolicies)
   {

--- a/src/windows/BooleanPolicy.cc
+++ b/src/windows/BooleanPolicy.cc
@@ -8,8 +8,8 @@
 
 using namespace Napi;
 
-BooleanPolicy::BooleanPolicy(const std::string& name, const std::string& productName)
-  : RegistryPolicy(name, productName, {REG_DWORD}) {}
+BooleanPolicy::BooleanPolicy(const std::string& name, const std::string& productName, const std::string &registryPath)
+  : RegistryPolicy(name, productName, {REG_DWORD}, registryPath) {}
 
 bool BooleanPolicy::parseRegistryValue(LPBYTE buffer, DWORD bufferSize, DWORD type) const
 {

--- a/src/windows/BooleanPolicy.hh
+++ b/src/windows/BooleanPolicy.hh
@@ -15,7 +15,7 @@ using namespace Napi;
 class BooleanPolicy : public RegistryPolicy<bool>
 {
 public:
-  BooleanPolicy(const std::string& name, const std::string &productName);
+  BooleanPolicy(const std::string& name, const std::string &productName, const std::string &registryPath = "");
 
 protected:
   bool parseRegistryValue(LPBYTE buffer, DWORD bufferSize, DWORD type) const;

--- a/src/windows/NumberPolicy.cc
+++ b/src/windows/NumberPolicy.cc
@@ -7,8 +7,8 @@
 
 using namespace Napi;
 
-NumberPolicy::NumberPolicy(const std::string name, const std::string &productName)
-    : RegistryPolicy(name, productName, {REG_QWORD}) {}
+NumberPolicy::NumberPolicy(const std::string name, const std::string &productName, const std::string &registryPath)
+    : RegistryPolicy(name, productName, {REG_QWORD}, registryPath) {}
 
 long long NumberPolicy::parseRegistryValue(LPBYTE buffer, DWORD bufferSize, DWORD type) const
 {

--- a/src/windows/NumberPolicy.hh
+++ b/src/windows/NumberPolicy.hh
@@ -15,7 +15,7 @@ using namespace Napi;
 class NumberPolicy : public RegistryPolicy<long long>
 {
 public:
-  NumberPolicy(const std::string name, const std::string &productName);
+  NumberPolicy(const std::string name, const std::string &productName, const std::string &registryPath = "");
 
 protected:
   long long parseRegistryValue(LPBYTE buffer, DWORD bufferSize, DWORD type) const;

--- a/src/windows/PolicyWatcher.cc
+++ b/src/windows/PolicyWatcher.cc
@@ -30,17 +30,17 @@ PolicyWatcher::~PolicyWatcher()
 
 void PolicyWatcher::AddStringPolicy(const std::string name)
 {
-  policies.push_back(std::make_unique<StringPolicy>(name, productName));
+  policies.push_back(std::make_unique<StringPolicy>(name, productName, registryPath));
 }
 
 void PolicyWatcher::AddNumberPolicy(const std::string name)
 {
-  policies.push_back(std::make_unique<NumberPolicy>(name, productName));
+  policies.push_back(std::make_unique<NumberPolicy>(name, productName, registryPath));
 }
 
 void PolicyWatcher::AddBooleanPolicy(const std::string name)
 {
-  policies.push_back(std::make_unique<BooleanPolicy>(name, productName));
+  policies.push_back(std::make_unique<BooleanPolicy>(name, productName, registryPath));
 }
 
 void PolicyWatcher::OnExecute(Napi::Env env)

--- a/src/windows/RegistryPolicy.hh
+++ b/src/windows/RegistryPolicy.hh
@@ -19,9 +19,9 @@ template <typename T>
 class RegistryPolicy : public Policy
 {
 public:
-  RegistryPolicy(const std::string name, const std::string &productName, const std::vector<DWORD>& types)
+  RegistryPolicy(const std::string name, const std::string &productName, const std::vector<DWORD>& types, const std::string &customRegistryPath = "")
       : Policy(name),
-        registryKey("Software\\Policies\\Microsoft\\" + productName),
+        registryKey(customRegistryPath.empty() ? ("Software\\Policies\\Microsoft\\" + productName) : customRegistryPath),
         supportedTypes(types) {}
 
   PolicyRefreshResult refresh()

--- a/src/windows/StringPolicy.cc
+++ b/src/windows/StringPolicy.cc
@@ -7,8 +7,8 @@
 
 using namespace Napi;
 
-StringPolicy::StringPolicy(const std::string name, const std::string &productName)
-    : RegistryPolicy(name, productName, {REG_SZ, REG_MULTI_SZ}) {}
+StringPolicy::StringPolicy(const std::string name, const std::string &productName, const std::string &registryPath)
+    : RegistryPolicy(name, productName, {REG_SZ, REG_MULTI_SZ}, registryPath) {}
 
 std::string StringPolicy::parseRegistryValue(LPBYTE buffer, DWORD bufferSize, DWORD type) const
 {

--- a/src/windows/StringPolicy.hh
+++ b/src/windows/StringPolicy.hh
@@ -15,7 +15,7 @@ using namespace Napi;
 class StringPolicy : public RegistryPolicy<std::string>
 {
 public:
-  StringPolicy(const std::string name, const std::string &productName);
+  StringPolicy(const std::string name, const std::string &productName, const std::string &registryPath = "");
 
 protected:
   std::string parseRegistryValue(LPBYTE buffer, DWORD bufferSize, DWORD type) const;


### PR DESCRIPTION
## Summary

Adds `WatcherOptions.registryPath` support to `@vscode/policy-watcher`, enabling consumers to specify a custom Windows registry path instead of the hardcoded `Software\Policies\Microsoft\<name>` default.

This is required for the GitHubCopilot managed-settings namespace (`SOFTWARE\Policies\GitHubCopilot`), which is shared across VS Code, Copilot CLI, and SDK integrators.

## Changes

- `index.d.ts`: New `WatcherOptions` interface with optional `registryPath`
- `src/main.cc`: Parses optional 4th argument, extracts `registryPath`
- `src/windows/RegistryPolicy.hh`: Accepts custom registry path, defaults to existing behavior
- `src/windows/StringPolicy.hh`, `NumberPolicy.hh`, `BooleanPolicy.hh`: Forward `registryPath`
- Version bump to 1.4.0

## Related

- Companion PR in microsoft/vscode (MDM and file-based delivery for managed settings V0)
- ADR: MDM and File-Based Delivery for Managed Settings

## Testing

- Compiled on macOS with `node-gyp rebuild`
- Windows registry path forwarding is structural: passes custom path to `RegistryPolicy` constructor