### PR TITLE
feat: support scalar union policy types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-2022]
         node-version: [22.x]
     steps:
       - name: Checkout

--- a/binding.gyp
+++ b/binding.gyp
@@ -18,7 +18,8 @@
                         "src/macos/PolicyWatcher.cc",
                         "src/macos/StringPolicy.cc",
                         "src/macos/NumberPolicy.cc",
-                        "src/macos/BooleanPolicy.cc"
+                        "src/macos/BooleanPolicy.cc",
+                        "src/macos/UnionPolicy.cc"
                     ],
                     "defines": [
                         "MACOS",
@@ -48,7 +49,8 @@
                         "src/windows/PolicyWatcher.cc",
                         "src/windows/StringPolicy.cc",
                         "src/windows/NumberPolicy.cc",
-                        "src/windows/BooleanPolicy.cc"
+                        "src/windows/BooleanPolicy.cc",
+                        "src/windows/UnionPolicy.cc"
                     ],
                     "defines": [
                         "WINDOWS"

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,9 +10,11 @@ interface Watcher {
 type StringPolicy = { type: "string" };
 type NumberPolicy = { type: "number" };
 type BooleanPolicy = { type: "boolean" };
+type PolicyType = "string" | "number" | "boolean";
+type UnionPolicy = { type: readonly [PolicyType, ...PolicyType[]] };
 
 export interface Policies {
-  [policyName: string]: StringPolicy | NumberPolicy | BooleanPolicy;
+  [policyName: string]: StringPolicy | NumberPolicy | BooleanPolicy | UnionPolicy;
 }
 
 export interface WatcherOptions {
@@ -23,14 +25,16 @@ export interface WatcherOptions {
 export type PolicyUpdate<T extends Policies> = {
   [K in keyof T]:
     | undefined
-    | (T[K] extends StringPolicy
-        ? string
-        : (T[K] extends BooleanPolicy
-        ? boolean
-        : T[K] extends NumberPolicy
-        ? number
-        : never));
+      | (T[K]["type"] extends readonly PolicyType[]
+          ? PolicyTypeValue<T[K]["type"][number]>
+          : PolicyTypeValue<T[K]["type"]>);
 };
+
+type PolicyTypeValue<T extends PolicyType> =
+    T extends "string" ? string :
+    T extends "boolean" ? boolean :
+    T extends "number" ? number :
+    never;
 
 export function createWatcher<T extends Policies>(
   productName: string,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vscode/policy-watcher",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vscode/policy-watcher",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vscode/policy-watcher",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "",
   "main": "index.js",
   "repository": {

--- a/src/PolicyWatcher.hh
+++ b/src/PolicyWatcher.hh
@@ -35,6 +35,7 @@ public:
   void AddStringPolicy(const std::string name);
   void AddNumberPolicy(const std::string name);
   void AddBooleanPolicy(const std::string name);
+  void AddUnionPolicy(const std::string name, const std::vector<std::string> &types);
 
   void OnExecute(Napi::Env env);
   void Execute(const ExecutionProgress &progress);

--- a/src/linux/PolicyWatcher.cc
+++ b/src/linux/PolicyWatcher.cc
@@ -20,6 +20,7 @@ PolicyWatcher::~PolicyWatcher()
 void PolicyWatcher::AddStringPolicy(const std::string name) {}
 void PolicyWatcher::AddNumberPolicy(const std::string name) {}
 void PolicyWatcher::AddBooleanPolicy(const std::string name) {}
+void PolicyWatcher::AddUnionPolicy(const std::string name, const std::vector<std::string> &types) {}
 void PolicyWatcher::OnExecute(Napi::Env env) {}
 void PolicyWatcher::Execute(const ExecutionProgress &progress) {}
 void PolicyWatcher::OnProgress(const Policy *const *policies, size_t count) {}

--- a/src/macos/PolicyWatcher.cc
+++ b/src/macos/PolicyWatcher.cc
@@ -7,6 +7,7 @@
 #include "StringPolicy.hh"
 #include "NumberPolicy.hh"
 #include "BooleanPolicy.hh"
+#include "UnionPolicy.hh"
 #include <thread>
 
 using namespace Napi;
@@ -55,6 +56,11 @@ void PolicyWatcher::AddNumberPolicy(const std::string name)
 void PolicyWatcher::AddBooleanPolicy(const std::string name)
 {
     policies.push_back(std::make_unique<BooleanPolicy>(name, productName));
+}
+
+void PolicyWatcher::AddUnionPolicy(const std::string name, const std::vector<std::string> &types)
+{
+  policies.push_back(std::make_unique<UnionPolicy>(name, productName, types));
 }
 
 void PolicyWatcher::OnExecute(Napi::Env env)

--- a/src/macos/PreferencesPolicy.hh
+++ b/src/macos/PreferencesPolicy.hh
@@ -31,6 +31,15 @@ public:
 
     PolicyRefreshResult refresh()
     {
+        if (!CFPreferencesAppValueIsForced(key, appID))
+        {
+            if (!value.has_value())
+                return PolicyRefreshResult::NotSet;
+
+            value.reset();
+            return PolicyRefreshResult::Removed;
+        }
+
         auto newValue = read();
 
         // Check for no value or removal

--- a/src/macos/UnionPolicy.cc
+++ b/src/macos/UnionPolicy.cc
@@ -1,0 +1,73 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+#include "UnionPolicy.hh"
+#include <CoreFoundation/CoreFoundation.h>
+
+UnionPolicy::UnionPolicy(const std::string name, const std::string &productName, const std::vector<std::string> &types)
+    : Policy(name),
+      appID(CFStringCreateWithCString(nullptr, productName.c_str(), kCFStringEncodingUTF8)),
+      key(CFStringCreateWithCString(nullptr, name.c_str(), kCFStringEncodingUTF8))
+{
+  for (const auto &type : types) {
+    acceptsBoolean = acceptsBoolean || type == "boolean";
+    acceptsNumber = acceptsNumber || type == "number";
+    acceptsString = acceptsString || type == "string";
+  }
+}
+
+UnionPolicy::~UnionPolicy()
+{
+  CFRelease(appID);
+  CFRelease(key);
+}
+
+PolicyRefreshResult UnionPolicy::refresh()
+{
+  auto next = read();
+  if (value == next)
+    return value.has_value() ? PolicyRefreshResult::Unchanged : PolicyRefreshResult::NotSet;
+  auto removed = value.has_value() && !next.has_value();
+  value = next;
+  return removed ? PolicyRefreshResult::Removed : PolicyRefreshResult::Updated;
+}
+
+Napi::Value UnionPolicy::getValue(Napi::Env env) const
+{
+  if (!value.has_value())
+    return env.Undefined();
+  if (std::holds_alternative<bool>(*value))
+    return Napi::Boolean::New(env, std::get<bool>(*value));
+  if (std::holds_alternative<double>(*value))
+    return Napi::Number::New(env, std::get<double>(*value));
+  return Napi::String::New(env, std::get<std::string>(*value));
+}
+
+std::optional<UnionPolicyValue> UnionPolicy::read() const
+{
+  if (!CFPreferencesAppValueIsForced(key, appID))
+    return std::nullopt;
+  auto pref = CFPreferencesCopyAppValue(key, appID);
+  if (pref == nullptr)
+    return std::nullopt;
+
+  std::optional<UnionPolicyValue> result;
+  auto type = CFGetTypeID(pref);
+  if (type == CFBooleanGetTypeID() && acceptsBoolean) {
+    result = pref == kCFBooleanTrue;
+  } else if (type == CFNumberGetTypeID() && acceptsNumber) {
+    long long number;
+    if (CFNumberGetValue(static_cast<CFNumberRef>(pref), kCFNumberLongLongType, &number))
+      result = static_cast<double>(number);
+  } else if (type == CFStringGetTypeID() && acceptsString) {
+    CFIndex length = CFStringGetLength(static_cast<CFStringRef>(pref));
+    CFIndex maxSize = CFStringGetMaximumSizeForEncoding(length, kCFStringEncodingUTF8) + 1;
+    std::vector<char> buffer(maxSize);
+    if (CFStringGetCString(static_cast<CFStringRef>(pref), buffer.data(), maxSize, kCFStringEncodingUTF8))
+      result = std::string(buffer.data());
+  }
+  CFRelease(pref);
+  return result;
+}

--- a/src/macos/UnionPolicy.hh
+++ b/src/macos/UnionPolicy.hh
@@ -1,0 +1,36 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+#ifndef UNION_POLICY_H
+#define UNION_POLICY_H
+
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+#include <CoreFoundation/CoreFoundation.h>
+#include "../Policy.hh"
+
+using UnionPolicyValue = std::variant<bool, double, std::string>;
+
+class UnionPolicy : public Policy
+{
+public:
+  UnionPolicy(const std::string name, const std::string &productName, const std::vector<std::string> &types);
+  ~UnionPolicy();
+  PolicyRefreshResult refresh();
+  Napi::Value getValue(Napi::Env env) const;
+
+private:
+  std::optional<UnionPolicyValue> read() const;
+  CFStringRef appID;
+  CFStringRef key;
+  bool acceptsBoolean = false;
+  bool acceptsNumber = false;
+  bool acceptsString = false;
+  std::optional<UnionPolicyValue> value;
+};
+
+#endif

--- a/src/main.cc
+++ b/src/main.cc
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 #include <napi.h>
+#include <algorithm>
 #include <vector>
 
 #include "Policy.hh"
@@ -67,21 +68,38 @@ Value CreateWatcher(const CallbackInfo &info)
 
     auto rawPolicy = rawPolicyValue.As<Object>();
     auto rawPolicyType = rawPolicy.Get("type");
-
-    if (!rawPolicyType.IsString())
-      throw TypeError::New(env, "Expected policy type to be string");
-
-    auto policyType = std::string(rawPolicyType.As<String>());
-
-    if (policyType == "string") {
-      watcher->AddStringPolicy(rawPolicyName.As<String>());
-    }
-    else if (policyType == "number") {
-      watcher->AddNumberPolicy(rawPolicyName.As<String>());
-    } else if (policyType == "boolean") {
-      watcher->AddBooleanPolicy(rawPolicyName.As<String>());
+    std::vector<std::string> policyTypes;
+    if (rawPolicyType.IsString()) {
+      policyTypes.push_back(std::string(rawPolicyType.As<String>()));
+    } else if (rawPolicyType.IsArray()) {
+      auto rawPolicyTypes = rawPolicyType.As<Array>();
+      if (rawPolicyTypes.Length() == 0)
+        throw TypeError::New(env, "Expected policy type array to be non-empty");
+      for (uint32_t i = 0; i < rawPolicyTypes.Length(); i++) {
+        auto rawType = rawPolicyTypes.Get(i);
+        if (!rawType.IsString())
+          throw TypeError::New(env, "Expected policy type array entries to be strings");
+        auto type = std::string(rawType.As<String>());
+        if (std::find(policyTypes.begin(), policyTypes.end(), type) == policyTypes.end())
+          policyTypes.push_back(type);
+      }
     } else {
-      throw TypeError::New(env, "Unknown policy type '" + policyType + "'");
+      throw TypeError::New(env, "Expected policy type to be a string or non-empty string array");
+    }
+
+    for (const auto &policyType : policyTypes) {
+      if (policyType != "string" && policyType != "number" && policyType != "boolean")
+        throw TypeError::New(env, "Unknown policy type '" + policyType + "'");
+    }
+
+    if (policyTypes.size() > 1) {
+      watcher->AddUnionPolicy(rawPolicyName.As<String>(), policyTypes);
+    } else if (policyTypes[0] == "string") {
+        watcher->AddStringPolicy(rawPolicyName.As<String>());
+    } else if (policyTypes[0] == "number") {
+        watcher->AddNumberPolicy(rawPolicyName.As<String>());
+    } else {
+        watcher->AddBooleanPolicy(rawPolicyName.As<String>());
     }
   }
 

--- a/src/windows/PolicyWatcher.cc
+++ b/src/windows/PolicyWatcher.cc
@@ -9,6 +9,7 @@
 #include "StringPolicy.hh"
 #include "NumberPolicy.hh"
 #include "BooleanPolicy.hh"
+#include "UnionPolicy.hh"
 
 using namespace Napi;
 
@@ -41,6 +42,11 @@ void PolicyWatcher::AddNumberPolicy(const std::string name)
 void PolicyWatcher::AddBooleanPolicy(const std::string name)
 {
   policies.push_back(std::make_unique<BooleanPolicy>(name, productName, registryPath));
+}
+
+void PolicyWatcher::AddUnionPolicy(const std::string name, const std::vector<std::string> &types)
+{
+  policies.push_back(std::make_unique<UnionPolicy>(name, productName, registryPath, types));
 }
 
 void PolicyWatcher::OnExecute(Napi::Env env)

--- a/src/windows/UnionPolicy.cc
+++ b/src/windows/UnionPolicy.cc
@@ -1,0 +1,92 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+#include "UnionPolicy.hh"
+#include <algorithm>
+#include <windows.h>
+
+UnionPolicy::UnionPolicy(const std::string name, const std::string &productName, const std::string &customRegistryPath, const std::vector<std::string> &types)
+    : Policy(name),
+      registryKey(customRegistryPath.empty() ? ("Software\\Policies\\Microsoft\\" + productName) : customRegistryPath)
+{
+  for (const auto &type : types) {
+    acceptsBoolean = acceptsBoolean || type == "boolean";
+    acceptsNumber = acceptsNumber || type == "number";
+    acceptsString = acceptsString || type == "string";
+  }
+}
+
+PolicyRefreshResult UnionPolicy::refresh()
+{
+  auto next = read(HKEY_LOCAL_MACHINE);
+  if (!next.has_value())
+    next = read(HKEY_CURRENT_USER);
+
+  if (value == next)
+    return value.has_value() ? PolicyRefreshResult::Unchanged : PolicyRefreshResult::NotSet;
+  auto removed = value.has_value() && !next.has_value();
+  value = next;
+  return removed ? PolicyRefreshResult::Removed : PolicyRefreshResult::Updated;
+}
+
+Napi::Value UnionPolicy::getValue(Napi::Env env) const
+{
+  if (!value.has_value())
+    return env.Undefined();
+  if (std::holds_alternative<bool>(*value))
+    return Napi::Boolean::New(env, std::get<bool>(*value));
+  if (std::holds_alternative<double>(*value))
+    return Napi::Number::New(env, std::get<double>(*value));
+  return Napi::String::New(env, std::get<std::string>(*value));
+}
+
+std::optional<UnionPolicyValue> UnionPolicy::read(HKEY root) const
+{
+  HKEY key;
+  if (RegOpenKeyEx(root, registryKey.c_str(), 0, KEY_READ, &key) != ERROR_SUCCESS)
+    return std::nullopt;
+
+  DWORD type;
+  DWORD size = 0;
+  auto status = RegQueryValueEx(key, name.c_str(), nullptr, &type, nullptr, &size);
+  if (status != ERROR_SUCCESS && status != ERROR_MORE_DATA) {
+    RegCloseKey(key);
+    return std::nullopt;
+  }
+
+  std::vector<BYTE> buffer(size);
+  status = RegQueryValueEx(key, name.c_str(), nullptr, &type, buffer.data(), &size);
+  RegCloseKey(key);
+  if (status != ERROR_SUCCESS)
+    return std::nullopt;
+
+  if (type == REG_DWORD && acceptsBoolean && size == sizeof(DWORD))
+    return *reinterpret_cast<DWORD *>(buffer.data()) != 0;
+  if (type == REG_QWORD && acceptsNumber && size == sizeof(long long))
+    return static_cast<double>(*reinterpret_cast<long long *>(buffer.data()));
+  if ((type == REG_SZ || type == REG_MULTI_SZ) && acceptsString) {
+    if (type == REG_SZ && size == 0)
+      return std::string();
+    const char *begin = reinterpret_cast<char *>(buffer.data());
+    const char *end = begin + size;
+    if (type == REG_SZ) {
+      const char *terminator = std::find(begin, end, '\0');
+      return std::string(begin, terminator);
+    }
+    if (size < 2 || end[-1] != '\0' || end[-2] != '\0')
+      return std::nullopt;
+    std::string result;
+    const char *current = begin;
+    while (current < end && *current != '\0') {
+      const char *terminator = std::find(current, end, '\0');
+      if (!result.empty())
+        result += '\n';
+      result.append(current, terminator);
+      current = terminator == end ? end : terminator + 1;
+    }
+    return result;
+  }
+  return std::nullopt;
+}

--- a/src/windows/UnionPolicy.hh
+++ b/src/windows/UnionPolicy.hh
@@ -1,0 +1,34 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+#ifndef UNION_POLICY_H
+#define UNION_POLICY_H
+
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+#include <windows.h>
+#include "../Policy.hh"
+
+using UnionPolicyValue = std::variant<bool, double, std::string>;
+
+class UnionPolicy : public Policy
+{
+public:
+  UnionPolicy(const std::string name, const std::string &productName, const std::string &registryPath, const std::vector<std::string> &types);
+  PolicyRefreshResult refresh();
+  Napi::Value getValue(Napi::Env env) const;
+
+private:
+  std::optional<UnionPolicyValue> read(HKEY root) const;
+  const std::string registryKey;
+  bool acceptsBoolean = false;
+  bool acceptsNumber = false;
+  bool acceptsString = false;
+  std::optional<UnionPolicyValue> value;
+};
+
+#endif


### PR DESCRIPTION
## Summary

- allow a policy key to declare a non-empty union of scalar native types
- read exact boolean/string/number representations through one per-key native policy
- preserve machine-over-user precedence and reject unforced macOS preferences
- keep existing single-type declarations on their established readers
- pin GitHub Windows CI to the Windows 2022 image supported by Node 22's node-gyp
- prepare the 1.5.0 package release

This unblocks the canonical `strictPluginOnlyCustomization` managed-setting key from carrying both its existing boolean form and its selective JSON-array string form without breaking deployed native booleans.

Dependent VS Code PR: microsoft/vscode#332071

## Validation

- authoritative Azure pipeline passes on Linux, macOS, Windows, package creation, and SDL analysis
- GitHub Actions passes on Linux, macOS, and Windows 2022, plus CodeQL
- local Windows native build (Node 24.18.0)
- manual registry reads for `REG_DWORD true` and `REG_SZ "[]"`
- two focused code-review passes over Windows and macOS native readers

## CI compatibility

GitHub's `windows-latest` image now exposes Visual Studio 2026, which Node 22's bundled node-gyp cannot identify. PR #76 pins the GitHub Windows job to `windows-2022`, retaining the supported Visual Studio 2022 toolchain while leaving the Azure Windows build unchanged.

## Release sequence

After approval and merge, run the existing Azure pipeline with `publishPackage: true` to publish `@vscode/policy-watcher@1.5.0`. The dependent VS Code draft will then replace its temporary 1.4 compatibility state with the published version and regenerated lockfile.